### PR TITLE
Use stable/mitaka for masakari-deploy

### DIFF
--- a/cookbooks/devstack/recipes/default.rb
+++ b/cookbooks/devstack/recipes/default.rb
@@ -23,7 +23,7 @@ git "/home/stack/devstack" do
   repository 'https://github.com/openstack-dev/devstack.git'
   ## use local repository
   #repository '/vagrant_openstack/devstack'
-  revision 'stable/liberty'
+  revision 'stable/mitaka'
   user 'stack'
   group 'stack'
   action :checkout


### PR DESCRIPTION
OpenStack mitaka has been released already and liberty is not under
maintenance release. close #8 
