### PR TITLE
Enable to deploy successfully in a recent environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ It contains Vagrantfile and chef recipes to deploy three VMs including OpenStack
   ```sh
   stack@controller:~/devstack$ nova hypervisor-servers compute1
   stack@controller:~/devstack$ nova hypervisor-servers compute2
-  $ nova --os-tenant-name demo instance-action-list vm2
+  $ nova --os-tenant-name demo instance-action-list vm1
   ```
 
 ### Recovery of Failed Host

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ It contains Vagrantfile and chef recipes to deploy three VMs including OpenStack
 * create a server instance
 
   ```sh
+  stack@controller:~/devstack$ . openrc admin admin
+  stack@controller:~/devstack$ nova flavor-create m1.nano auto 64 1 1
   stack@controller:~/devstack$ . openrc demo demo
   stack@controller:~/devstack$ nova boot --image cirros-0.3.4-x86_64-uec --flavor m1.nano vm1
   ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -195,7 +195,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       # Chef uses doc by default when you run it directly from the command line.
       # Vagrant, on the other hand, applies null by default
       chef.formatter = ENV.fetch("CHEF_FORMAT", "null").downcase.to_sym
-      chef.arguments = '-l debug'
+      chef.arguments = '-l debug --legacy-mode'
       chef.roles_path = "roles"
       chef.add_role("controller")
       chef.json = {
@@ -223,7 +223,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     compute1.vm.provision "chef_solo" do |chef|
       chef.log_level = ENV.fetch("CHEF_LOG", "info").downcase.to_sym
       chef.formatter = ENV.fetch("CHEF_FORMAT", "null").downcase.to_sym
-      chef.arguments = '-l debug'
+      chef.arguments = '-l debug --legacy-mode'
       chef.roles_path = "roles"
       chef.add_role("compute")
       chef.json = {
@@ -249,7 +249,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     compute2.vm.provision "chef_solo" do |chef|
       chef.log_level = ENV.fetch("CHEF_LOG", "info").downcase.to_sym
       chef.formatter = ENV.fetch("CHEF_FORMAT", "null").downcase.to_sym
-      chef.arguments = '-l debug'
+      chef.arguments = '-l debug --legacy-mode'
       chef.roles_path = "roles"
       chef.add_role("compute")
       chef.json = {

--- a/cookbooks/masakari_controller_conf/recipes/default.rb
+++ b/cookbooks/masakari_controller_conf/recipes/default.rb
@@ -3,10 +3,15 @@ when 'ubuntu', 'debian'
   package ['build-essential', 'python-dev', 'python-pip', 'libmysqlclient-dev', 'libffi-dev', 'libssl-dev'] do
     action :install
   end
+  execute "upgrade pip" do
+    command "pip install -U pip"
+    user "root"
+  end
   execute "masakari requirements" do
     command "pip install -r requirements.txt"
     cwd "/home/stack/masakari/masakari-controller/"
     user "root"
+    environment 'PATH' => "/usr/local/bin:#{ENV['PATH']}"
   end
   dpkg_package "masakari-controller_1.0.0-1_all" do
     source '/home/stack/masakari/masakari-controller_1.0.0-1_all.deb'
@@ -16,10 +21,15 @@ when 'redhat', 'centos'
   package ['python-setuptools', 'python-devel', 'mariadb-devel', 'python-pip', 'libffi-devel', 'openssl-devel'] do
     action :install
   end
+  execute "upgrade pip" do
+    command "pip install -U pip"
+    user "root"
+  end
   execute "masakari requirements" do
     command "pip install -r requirements.txt"
     cwd "/home/stack/masakari/masakari-controller/"
     user "root"
+    environment 'PATH' => "/usr/local/bin:#{ENV['PATH']}"
   end
   rpm_package "masakari-controller-1.0.0-1.x86_64" do
     source "/home/stack/masakari/masakari-controller-1.0.0-1.x86_64.rpm"

--- a/cookbooks/masakari_controller_conf/recipes/default.rb
+++ b/cookbooks/masakari_controller_conf/recipes/default.rb
@@ -1,6 +1,6 @@
 case node[:platform]
 when 'ubuntu', 'debian'
-  package ['build-essential', 'python-dev', 'python-pip', 'libmysqlclient-dev'] do
+  package ['build-essential', 'python-dev', 'python-pip', 'libmysqlclient-dev', 'libffi-dev', 'libssl-dev'] do
     action :install
   end
   execute "masakari requirements" do
@@ -13,7 +13,7 @@ when 'ubuntu', 'debian'
     action :install
   end
 when 'redhat', 'centos'
-  package ['python-setuptools', 'python-devel', 'mariadb-devel', 'python-pip'] do
+  package ['python-setuptools', 'python-devel', 'mariadb-devel', 'python-pip', 'libffi-devel', 'openssl-devel'] do
     action :install
   end
   execute "masakari requirements" do

--- a/cookbooks/masakari_controller_conf/templates/default/masakari-controller.conf.erb
+++ b/cookbooks/masakari_controller_conf/templates/default/masakari-controller.conf.erb
@@ -13,6 +13,8 @@ innodb_lock_wait_timeout = 50
 
 [log]
 log_level = info
+log_file = /var/log/masakari/masakari-controller.log
+logging_context_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(threadName)s] %(message)s
 
 [recover_starter]
 interval_to_be_retry = 300


### PR DESCRIPTION
This PR enables to deploy successfully in a recent environment. 

- Install libffi-dev and libssl-dev which are required by python packages
- Add `--legacy-mode` to chef.arguments
- Upgrade pip before installing python packages
- Add mandatory configs to masakari-controller.conf
- Create the m1.nano flavor

